### PR TITLE
fix: Use TMDB ID instead of TVDB ID for Jellyseerr TV show requests

### DIFF
--- a/internal/integrations/jellyseerr.go
+++ b/internal/integrations/jellyseerr.go
@@ -40,7 +40,7 @@ type MovieRequest struct {
 // ShowRequest represents a TV show request payload
 type ShowRequest struct {
 	MediaType string `json:"mediaType"`
-	MediaID   int    `json:"mediaId"` // TVDB ID
+	MediaID   int    `json:"mediaId"` // TMDB ID (Jellyseerr uses TMDB for TV shows, not TVDB)
 	Seasons   string `json:"seasons"` // "all" or specific seasons
 	UserID    *int   `json:"userId,omitempty"`
 }
@@ -145,11 +145,11 @@ func (j *Jellyseerr) RequestMovie(tmdbID int) (*RequestResponse, error) {
 	return &result, nil
 }
 
-// RequestShow requests a TV show by TVDB ID
-func (j *Jellyseerr) RequestShow(tvdbID int) (*RequestResponse, error) {
+// RequestShow requests a TV show by TMDB ID
+func (j *Jellyseerr) RequestShow(tmdbID int) (*RequestResponse, error) {
 	payload := ShowRequest{
 		MediaType: "tv",
-		MediaID:   tvdbID,
+		MediaID:   tmdbID,
 		Seasons:   "all",
 	}
 

--- a/internal/services/jobs/anticipated_shows.go
+++ b/internal/services/jobs/anticipated_shows.go
@@ -233,7 +233,7 @@ func runAnticipatedShowsJellyseerr(ctx context.Context, cfg *config.Config, db *
 			log.Infof("[DRY RUN] Would request anticipated show '%s (%d)' via Jellyseerr", anticipated.Show.Title, anticipated.Show.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", anticipated.Show.Title, anticipated.Show.Year, err)
 				failed++

--- a/internal/services/jobs/collected_shows.go
+++ b/internal/services/jobs/collected_shows.go
@@ -233,7 +233,7 @@ func runCollectedShowsJellyseerr(ctx context.Context, cfg *config.Config, db *da
 			log.Infof("[DRY RUN] Would request collected show '%s (%d)' via Jellyseerr", collected.Show.Title, collected.Show.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", collected.Show.Title, collected.Show.Year, err)
 				failed++

--- a/internal/services/jobs/favorited_shows.go
+++ b/internal/services/jobs/favorited_shows.go
@@ -233,7 +233,7 @@ func runFavoritedShowsJellyseerr(ctx context.Context, cfg *config.Config, db *da
 			log.Infof("[DRY RUN] Would request favorited show '%s (%d)' via Jellyseerr", favorited.Show.Title, favorited.Show.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", favorited.Show.Title, favorited.Show.Year, err)
 				failed++

--- a/internal/services/jobs/played_shows.go
+++ b/internal/services/jobs/played_shows.go
@@ -233,7 +233,7 @@ func runPlayedShowsJellyseerr(ctx context.Context, cfg *config.Config, db *datab
 			log.Infof("[DRY RUN] Would request played show '%s (%d)' via Jellyseerr", played.Show.Title, played.Show.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", played.Show.Title, played.Show.Year, err)
 				failed++

--- a/internal/services/jobs/popular_shows.go
+++ b/internal/services/jobs/popular_shows.go
@@ -220,7 +220,7 @@ func runPopularShowsJellyseerr(ctx context.Context, cfg *config.Config, db *data
 			log.Infof("[DRY RUN] Would request popular show '%s (%d)' via Jellyseerr", popular.Title, popular.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", popular.Title, popular.Year, err)
 				failed++

--- a/internal/services/jobs/trending_shows.go
+++ b/internal/services/jobs/trending_shows.go
@@ -234,7 +234,7 @@ func runTrendingShowsJellyseerr(ctx context.Context, cfg *config.Config, db *dat
 			log.Infof("[DRY RUN] Would request trending show '%s (%d)' via Jellyseerr", trending.Show.Title, trending.Show.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", trending.Show.Title, trending.Show.Year, err)
 				failed++

--- a/internal/services/jobs/watched_shows.go
+++ b/internal/services/jobs/watched_shows.go
@@ -233,7 +233,7 @@ func runWatchedShowsJellyseerr(ctx context.Context, cfg *config.Config, db *data
 			log.Infof("[DRY RUN] Would request watched show '%s (%d)' via Jellyseerr", watched.Show.Title, watched.Show.Year)
 			added++
 		} else {
-			result, err := jellyseerrClient.RequestShow(series.TvdbID)
+			result, err := jellyseerrClient.RequestShow(series.TmdbID)
 			if err != nil {
 				log.Errorf("Failed to request show '%s (%d)' via Jellyseerr: %v", watched.Show.Title, watched.Show.Year, err)
 				failed++


### PR DESCRIPTION
Jellyseerr's API expects TMDB IDs for TV shows, not TVDB IDs. The code was incorrectly passing series.TvdbID to the RequestShow endpoint, causing 500 errors with the message "[TMDB] Failed to fetch TV show details: Request failed with status code 404".

Changes:
- Updated jellyseerr.RequestShow() to accept tmdbID instead of tvdbID
- Updated comment in ShowRequest struct to clarify TMDB is expected
- Updated all 7 job files that call RequestShow to pass series.TmdbID:
  * anticipated_shows.go
  * collected_shows.go
  * favorited_shows.go
  * played_shows.go
  * popular_shows.go
  * trending_shows.go
  * watched_shows.go

This fix resolves the issue where anticipated/unreleased shows were failing to be requested via Jellyseerr.

Fixes #4